### PR TITLE
Fix ajv and ajv-cli versions to yesterday's version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ install:
  - sudo apt-get install -y shunit2
 
 before_script:
- - npm install ajv
- - npm install -g ajv-cli
+ - npm install ajv@4.11.7
+ - npm install -g ajv-cli@1.1.2
 
 script:
  - sh test/ci-test-weather.sh


### PR DESCRIPTION
New versions of ajv (https://github.com/epoberezkin/ajv/releases) and ajv-cli (https://github.com/jessedc/ajv-cli/releases) released hours ago broke the master.

To go with latest versions we might need to upgrade the schemas, as suggested in https://github.com/epoberezkin/ajv/releases/tag/5.0.0. 

Let's do that more carefully in a different branch to keep master running fine.